### PR TITLE
Use new 5.4 showLabelOnHover feature for groups

### DIFF
--- a/frontend/src/pages/GraphPF/styles/styleGroup.tsx
+++ b/frontend/src/pages/GraphPF/styles/styleGroup.tsx
@@ -102,6 +102,7 @@ const StyleGroupComponent: React.FC<StyleGroupProps> = ({
         collapsedHeight={collapsedHeight}
         hulledOutline={false}
         showLabel={detailsLevel === ScaleDetailsLevel.high}
+        showLabelOnHover={true}
         {...rest}
         {...passedData}
       >

--- a/frontend/src/pages/Mesh/styles/MeshGroup.tsx
+++ b/frontend/src/pages/Mesh/styles/MeshGroup.tsx
@@ -79,6 +79,7 @@ const MeshGroupComponent: React.FC<MeshGroupProps> = ({
         collapsedHeight={collapsedHeight}
         hulledOutline={false}
         showLabel={detailsLevel === ScaleDetailsLevel.high}
+        showLabelOnHover={true}
         {...rest}
         {...passedData}
       >


### PR DESCRIPTION
Use new 5.4 showLabelOnHover feature for groups

![image](https://github.com/user-attachments/assets/2bad7a76-f00f-4dec-baba-2ef8d580ef8e)
