### PR TITLE
[PR-9289] Additional Fix for Service Graphs

### DIFF
--- a/frontend/src/pages/Graph/GraphPage.tsx
+++ b/frontend/src/pages/Graph/GraphPage.tsx
@@ -96,6 +96,7 @@ type ReduxDispatchProps = {
   setActiveNamespaces: (namespaces: Namespace[]) => void;
   setEdgeMode: (edgeMode: EdgeMode) => void;
   setGraphDefinition: (graphDefinition: GraphDefinition) => void;
+  setGraphType: (graphType: GraphType) => void;
   setLayout: (layout: GraphLayout) => void;
   setNode: (node?: NodeParamsType) => void;
   setRankResult: (result: RankResult) => void;
@@ -386,8 +387,21 @@ class GraphPageComponent extends React.Component<GraphPageProps, GraphPageState>
       HistoryManager.setParam(URLParam.GRAPH_LAYOUT, this.props.layout);
     }
 
+    // Sync graphType from URL before initial fetch so we don't fetch with default then again after toolbar sync.
+    const urlGraphType = HistoryManager.getParam(URLParam.GRAPH_TYPE) as GraphType;
+    const graphTypeSyncedFromUrl = !!urlGraphType && urlGraphType !== this.props.graphType;
+    if (graphTypeSyncedFromUrl) {
+      this.props.setGraphType(urlGraphType);
+    }
+
     // Unless we are waiting for Manual refresh, ensure we initialize the graph.
-    if (this.props.refreshInterval !== RefreshIntervalManual && HistoryManager.getRefresh() !== RefreshIntervalManual) {
+    // When graphType was just synced from URL, skip the initial fetch here; componentDidUpdate will run
+    // once Redux updates and trigger a single fetch with the correct graphType.
+    if (
+      !graphTypeSyncedFromUrl &&
+      this.props.refreshInterval !== RefreshIntervalManual &&
+      HistoryManager.getRefresh() !== RefreshIntervalManual
+    ) {
       // Using setTimeout() ensures we wait for the toolbar to render and ensure all redux props are updated
       // with URL settings. That in turn ensures the initial fetchParams are correct.
       setTimeout(() => this.loadGraphDataFromBackend(), 0);
@@ -852,6 +866,7 @@ const mapDispatchToProps = (dispatch: KialiDispatch): ReduxDispatchProps => ({
   setActiveNamespaces: (namespaces: Namespace[]) => dispatch(NamespaceActions.setActiveNamespaces(namespaces)),
   setEdgeMode: bindActionCreators(GraphActions.setEdgeMode, dispatch),
   setGraphDefinition: bindActionCreators(GraphActions.setGraphDefinition, dispatch),
+  setGraphType: bindActionCreators(GraphToolbarActions.setGraphType, dispatch),
   setLayout: bindActionCreators(GraphActions.setLayout, dispatch),
   setNode: bindActionCreators(GraphActions.setNode, dispatch),
   setRankResult: bindActionCreators(GraphActions.setRankResult, dispatch),

--- a/frontend/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/frontend/src/pages/Graph/SummaryPanelGraph.tsx
@@ -4,7 +4,7 @@ import { Node, Visualization } from '@patternfly/react-topology';
 import { kialiStyle } from 'styles/StyleUtils';
 import { RateTableGrpc, RateTableHttp, RateTableTcp } from '../../components/SummaryPanel/RateTable';
 import { RequestChart, StreamChart } from '../../components/SummaryPanel/RpsChart';
-import { NodeAttr, NodeType, Protocol, SummaryPanelPropType, TrafficRate, UNKNOWN } from '../../types/Graph';
+import { GraphType, NodeAttr, NodeType, Protocol, SummaryPanelPropType, TrafficRate, UNKNOWN } from '../../types/Graph';
 import {
   getAccumulatedTrafficRateGrpc,
   getAccumulatedTrafficRateHttp,
@@ -34,7 +34,7 @@ import { ValidationSummary } from 'components/Validations/ValidationSummary';
 import { ValidationSummaryLink } from '../../components/Link/ValidationSummaryLink';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { NodeData } from 'pages/Graph/GraphElems';
-import { edgesIn, edgesOut, elems, select } from 'helpers/GraphHelpers';
+import { edgesIn, edgesOut, elems, select, selectOr } from 'helpers/GraphHelpers';
 import { SimpleTabs } from 'components/Tab/SimpleTabs';
 import { panelHeadingStyle, panelStyle } from './SummaryPanelStyle';
 import { ApiResponse } from 'types/Api';
@@ -362,9 +362,17 @@ export class SummaryPanelGraph extends React.Component<SummaryPanelPropType, Sum
     const controller = this.props.data.summaryTarget as Visualization;
     const { nodes } = elems(controller);
 
-    // when getting total traffic rates don't count requests from injected service nodes
-    const nonServiceNodes = select(nodes, { prop: NodeAttr.nodeType, val: NodeType.SERVICE, op: '!=' });
-    const nonBoxNodes = select(nonServiceNodes, { prop: NodeAttr.isBox, op: 'falsy' });
+    // when getting total traffic rates don't count requests from injected service nodes.
+    // Service graph is built by reducing an injected workload graph, so its nodes still have
+    // isInjected=true; for that graph type use all nodes for total.
+    const nodesForTotal =
+      this.props.graphType === GraphType.SERVICE
+        ? nodes
+        : selectOr(nodes, [
+            [{ prop: NodeAttr.nodeType, op: '!=', val: NodeType.SERVICE }],
+            [{ prop: NodeAttr.isInjected, op: 'falsy' }]
+          ]);
+    const nonBoxNodes = select(nodesForTotal, { prop: NodeAttr.isBox, op: 'falsy' });
     const totalEdges = edgesOut(nonBoxNodes as Node[]);
     const inboundEdges = edgesOut(select(nodes, { prop: NodeAttr.isRoot, op: 'truthy' }) as Node[]);
 

--- a/frontend/src/store/Selectors/GraphData.ts
+++ b/frontend/src/store/Selectors/GraphData.ts
@@ -72,6 +72,7 @@ export const decorateGraphData = (graphData: GraphElements, duration: number): D
       isGateway: undefined,
       isIdle: undefined,
       isInaccessible: undefined,
+      isInjected: undefined,
       isIstio: undefined,
       isMisconfigured: undefined,
       isOutside: undefined,

--- a/frontend/src/types/Graph.ts
+++ b/frontend/src/types/Graph.ts
@@ -419,6 +419,7 @@ export interface GraphNodeData {
   };
   isIdle?: boolean;
   isInaccessible?: boolean;
+  isInjected?: boolean;
   isK8sGatewayAPI?: boolean;
   isMisconfigured?: string;
   isOutOfMesh?: boolean;
@@ -621,6 +622,7 @@ export const NodeAttr = {
   isGateway: 'isGateway',
   isIdle: 'isIdle',
   isInaccessible: 'isInaccessible',
+  isInjected: 'isInjected',
   isIstio: 'isIstio',
   isMisconfigured: 'isMisconfigured',
   isOutOfMesh: 'isOutOfMesh',

--- a/graph/config/common/common.go
+++ b/graph/config/common/common.go
@@ -108,6 +108,7 @@ type NodeData struct {
 	IsGateway             *GWInfo             `json:"isGateway,omitempty"`             // Istio ingress/egress gateway information
 	IsIdle                bool                `json:"isIdle,omitempty"`                // true | false
 	IsInaccessible        bool                `json:"isInaccessible,omitempty"`        // true if the node exists in an inaccessible namespace
+	IsInjected            bool                `json:"isInjected,omitempty"`            // true when node is an injected (synthetic) service node
 	IsK8sGatewayAPI       bool                `json:"isK8sGatewayAPI,omitempty"`       // true (object is auto-generated from K8s API Gateway) | false
 	IsOutOfMesh           bool                `json:"isOutOfMesh,omitempty"`           // true (has missing sidecar) | false
 	IsOutside             bool                `json:"isOutside,omitempty"`             // true | false
@@ -326,6 +327,11 @@ func buildConfig(trafficMap graph.TrafficMap, nodes *[]*NodeWrapper, edges *[]*E
 		// node is not accessible to the current user
 		if val, ok := n.Metadata[graph.IsInaccessible]; ok {
 			nd.IsInaccessible = val.(bool)
+		}
+
+		// node may be an injected (synthetic) service node - exclude from total traffic in app/workload graphs
+		if val, ok := n.Metadata[graph.IsInjected]; ok {
+			nd.IsInjected = val.(bool)
 		}
 
 		// node may have a circuit breaker


### PR DESCRIPTION
There is still a total traffic problem when graphType=service. We are assuming all service nodes are injected service nodes. Make the injected service node check explicit, but handle the fact that service graphs are naturally made up of injected service nodes.

This also includes an unrelated but potentially fix: The graph page, on an initial render (like F5) was making two requests to the backend if the URL graphType was not the default. Each request used the correct graphType, but the timing of the redux change forced a second update.
